### PR TITLE
Proper faker usage

### DIFF
--- a/tests/_data/merchant_relationship.databuilder.xml
+++ b/tests/_data/merchant_relationship.databuilder.xml
@@ -6,8 +6,8 @@
 >
 
     <transfer name="MerchantRelationship">
-        <property name="merchantRelationshipKey" dataBuilderRule="unique()->word"/>
-        <property name="name" dataBuilderRule="word"/>
+        <property name="merchantRelationshipKey" dataBuilderRule="unique()->word()"/>
+        <property name="name" dataBuilderRule="word()"/>
     </transfer>
 
 </transfers>


### PR DESCRIPTION
Not using faker methods as function is deprecated.

## PR Description

Make sure databuilder rules are not built using deprecated way to do it

## Checklist
- [ X] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
